### PR TITLE
Removed reference to future V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,3 @@ Fork this repo and click the button below to deploy.
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
 
 See the guide at https://render.com/docs/deploy-strapi for more information.
-
-## Test Strapi v4
-
-We plan to update this repository to v4 of Strapi shortly after [StrapiConf 2022](https://conf.strapi.io), however you may test out v4 on Render now by selecting the [`crc/upgrade-to-v4`](https://github.com/render-examples/strapi-postgres/pull/9) branch during deploy.


### PR DESCRIPTION
After todays update it is running Strapi v4 and the reference is not longer valid